### PR TITLE
Add policy related perms to RPK User

### DIFF
--- a/iam_rpk_user.tf
+++ b/iam_rpk_user.tf
@@ -359,6 +359,26 @@ data "aws_iam_policy_document" "byovpc_rpk_user_2" {
       }
     }
   }
+
+  statement {
+    # The user may create policy documents as long as they have the required tags
+    effect = "Allow"
+    actions = [
+      "iam:CreatePolicy",
+      "iam:TagPolicy"
+    ]
+    resources = ["*"]
+    dynamic "condition" {
+      for_each = var.condition_tags
+      content {
+        test     = "StringEquals"
+        variable = "aws:RequestTag/${condition.key}"
+        values = [
+          condition.value,
+        ]
+      }
+    }
+  }
 }
 
 resource "aws_iam_policy" "byovpc_rpk_user_1" {


### PR DESCRIPTION
I tested the minimum required permissions for the rpk user as of today. (Hadn't tested them in a while.) And discovered that these two permissions were missing.

Resulting errors looked like:

```
Error: creating IAM Policy... is not authorized to perform: iam:CreatePolicy
Error: creating IAM Policy... is not authorized to perform: iam:TagPolicy
```