### PR TITLE
fix: id to arn for private subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,4 @@ module "redpanda_byoc" {
   }
 }
 ```
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,15 +38,6 @@ output "vpc_arn" {
   value = data.aws_vpc.redpanda.arn
 }
 
-output "private_subnet_ids" {
-  value       = jsonencode([for o in data.aws_subnet.private : o["arn"]])
-  description = "Private subnet IDs created"
-  precondition {
-    condition     = length(data.aws_subnet.private) > 0
-    error_message = "Either the variable private_subnet_cidrs or private_subnet_ids is required."
-  }
-}
-
 output "redpanda_agent_security_group_arn" {
   value       = aws_security_group.redpanda_agent.arn
   description = "ID of the redpanda agent security group"
@@ -87,10 +78,13 @@ output "permissions_boundary_policy_arn" {
   description = "ARN of the policy boundary which is required to be included on any roles created by the Redpanda agent"
 }
 
-
 output "private_subnet_arns" {
-  description = "List of ARNs of the private subnets"
+  description = "List of private subnet ARNs"
   value = [
     for subnet in aws_subnet.private : subnet.arn
   ]
+  precondition {
+    condition     = length(data.aws_subnet.private) > 0
+    error_message = "Either the variable private_subnet_cidrs or private_subnet_ids is required."
+  }
 }


### PR DESCRIPTION
We use arn for all other outputs that return arns except this one. It makes sense to standardize it. I also cleaned up a duplicate -- but less well developed -- output with the arn name created because I was myself confused by this 😂

Note that this would be a breaking change and should only be included in a major version release. It is also not urgent, just a cleanup. 