### PR TITLE
Add iam:DeletePolicy for rpk user

### DIFF
--- a/iam_rpk_user.tf
+++ b/iam_rpk_user.tf
@@ -127,6 +127,16 @@ data "aws_iam_policy_document" "byovpc_rpk_user_1" {
   statement {
     effect = "Allow"
     actions = [
+      "iam:DeletePolicy",
+    ]
+    resources = [
+      "arn:aws:iam::${local.aws_account_id}:policy/redpanda-cloud-storage-manager-*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
       "iam:GetInstanceProfile",
     ]
     resources = concat([


### PR DESCRIPTION
The cloud-storage-manager policy is created during bootstrap and therefore it should be allowed that the rpk test user is allowed to delete it when running rpk destroy.