### PR TITLE
Add permission for iam:CreateServiceLinkedRole

### DIFF
--- a/iam_redpanda_agent.tf
+++ b/iam_redpanda_agent.tf
@@ -476,6 +476,19 @@ data "aws_iam_policy_document" "redpanda_agent2" {
       }
     }
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreateServiceLinkedRole",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:AWSServiceName"
+      values   = ["eks.amazonaws.com"]
+    }
+  }
 }
 
 # The agent will need to create 5 roles that can only be created after the kubernetes cluster has been created:

--- a/iam_utility_node_group.tf
+++ b/iam_utility_node_group.tf
@@ -592,6 +592,19 @@ data "aws_iam_policy_document" "load_balancer_controller_2" {
       }
     }
   }
+
+  statement {
+    sid       = ""
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["iam:CreateServiceLinkedRole"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:AWSServiceName"
+      values   = ["elasticloadbalancing.amazonaws.com"]
+    }
+  }
 }
 
 resource "aws_iam_policy" "load_balancer_controller_policy" {


### PR DESCRIPTION
This is required on brand new aws projects that have never yet hosted an EKS cluster.

ref: https://github.com/redpanda-data/cloud-examples/pull/58