### PR TITLE
update iam redpanda agent for eks managed nodepools

### DIFF
--- a/iam_redpanda_agent.tf
+++ b/iam_redpanda_agent.tf
@@ -287,6 +287,7 @@ data "aws_iam_policy_document" "redpanda_agent1" {
     ]
     resources = [
       "arn:aws:eks:*:${local.aws_account_id}:cluster/redpanda-*",
+      "arn:aws:eks:*:${local.aws_account_id}:nodegroup/redpanda-*",
       "arn:aws:eks:*:${local.aws_account_id}:addon/*",
     ]
   }
@@ -368,6 +369,7 @@ data "aws_iam_policy_document" "redpanda_agent2" {
       "arn:aws:iam::${local.aws_account_id}:role/redpanda-*-redpanda-connect",
       "arn:aws:iam::${local.aws_account_id}:role/redpanda-*-redpanda-connect-pipeline",
       "arn:aws:iam::${local.aws_account_id}:role/redpanda-*-operator-role",
+      "arn:aws:iam::${local.aws_account_id}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup",
       aws_iam_role.redpanda_agent.arn,
       aws_iam_role.redpanda_node_group.arn,
       aws_iam_role.redpanda_utility_node_group.arn,


### PR DESCRIPTION
Add the necessary changes to support creating EKS managed node groups for BYOVPC clusters.

The objective is to use EKS managed nodes for all AWS-based clusters. My first attempt was rolled back due to issues affecting BYOVPC clusters, which are outlined in this Slack thread:
https://redpandadata.slack.com/archives/C03FHLV038W/p1740539761199609

I'm now manually retrying the creation of BYOVPC clusters, and this PR includes the required changes to allow successful provisioning.