### PR TITLE
Allow agent permissions to redpanda-connect-mcp_server-secrets-manager policy

### DIFF
--- a/iam_redpanda_agent.tf
+++ b/iam_redpanda_agent.tf
@@ -652,6 +652,7 @@ data "aws_iam_policy_document" "agent_permissions_boundary_scoped_iam" {
       "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-redpanda-connect-pipeline-secrets-manager",
       "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-secrets-reader-operator",
       "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-cluster-secrets-reader",
+      "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-redpanda-connect-mcp_server-secrets-manager"
     ]
   }
 


### PR DESCRIPTION
Required for upcoming MCP feature.