### PR TITLE
buildkite: migrate from k8s-builders to cloud-m4xlarge pool

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: k8s-builders
+  queue: cloud-m4xlarge
 
 steps:
   - label: TFLint


### PR DESCRIPTION
## Summary

Migrate Buildkite pipeline from the manually-deployed `k8s-builders` pool to the Terraform-managed `cloud-m4xlarge` pool.

Part of [DEVPROD-2815](https://redpandadata.atlassian.net/browse/DEVPROD-2815).

[DEVPROD-2815]: https://redpandadata.atlassian.net/browse/DEVPROD-2815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ