### PR TITLE
fix: gate aws_eip.nat_gateway on public subnet existence

### DIFF
--- a/nat.tf
+++ b/nat.tf
@@ -4,6 +4,11 @@ resource "aws_eip" "nat_gateway" {
   tags   = var.default_tags
 }
 
+moved {
+  from = aws_eip.nat_gateway
+  to   = aws_eip.nat_gateway[0]
+}
+
 resource "aws_internet_gateway" "redpanda" {
   count  = local.create_vpc || var.create_internet_gateway ? 1 : 0
   vpc_id = data.aws_vpc.redpanda.id

--- a/nat.tf
+++ b/nat.tf
@@ -1,4 +1,5 @@
 resource "aws_eip" "nat_gateway" {
+  count  = length(aws_subnet.public) > 0 ? 1 : 0
   domain = "vpc"
   tags   = var.default_tags
 }
@@ -11,7 +12,7 @@ resource "aws_internet_gateway" "redpanda" {
 
 resource "aws_nat_gateway" "redpanda" {
   count         = length(aws_subnet.public) > 0 ? 1 : 0
-  allocation_id = aws_eip.nat_gateway.id
+  allocation_id = aws_eip.nat_gateway[0].id
   subnet_id     = aws_subnet.public[0].id
   depends_on = [
     aws_internet_gateway.redpanda,


### PR DESCRIPTION
Fixes #45.

## Summary

The `aws_eip.nat_gateway` resource is created unconditionally, even when no public subnets are configured (e.g. BYOVPC deployments using only private subnets with egress routed through a Transit Gateway / centralized firewall).

This breaks `terraform apply` in environments where SCPs explicitly deny `ec2:AllocateAddress` for accounts that intentionally have no public-internet egress requirement, since the EIP allocation runs even though the corresponding `aws_nat_gateway.redpanda` is correctly skipped.

## Change

- Add `count = length(aws_subnet.public) > 0 ? 1 : 0` to `aws_eip.nat_gateway`, matching the existing guard on `aws_nat_gateway.redpanda`.
- Update the NAT gateway's `allocation_id` reference from `aws_eip.nat_gateway.id` to `aws_eip.nat_gateway[0].id` to match the new collection form.

```diff
 resource "aws_eip" "nat_gateway" {
+  count  = length(aws_subnet.public) > 0 ? 1 : 0
   domain = "vpc"
   tags   = var.default_tags
 }

 resource "aws_nat_gateway" "redpanda" {
   count         = length(aws_subnet.public) > 0 ? 1 : 0
-  allocation_id = aws_eip.nat_gateway.id
+  allocation_id = aws_eip.nat_gateway[0].id
```

## Repro

Set `public_subnet_cidrs = []` (or omit) and pass `private_subnet_ids = [...]` for an existing VPC with TGW-based egress. Without this fix, apply attempts to allocate an unused EIP and fails in accounts with SCPs denying `ec2:AllocateAddress`.

## Test plan

- [ ] `terraform plan` with `public_subnet_cidrs = []` no longer plans to create `aws_eip.nat_gateway`
- [ ] `terraform plan` with `public_subnet_cidrs = ["10.0.100.0/24"]` still plans to create both the EIP and NAT gateway
- [ ] Existing deployments with public subnets unaffected (state migration not required - EIP becomes `[0]`, but Terraform infers index from existing single instance)

> Note: existing users with public subnets may need a one-time `terraform state mv 'module.X.aws_eip.nat_gateway' 'module.X.aws_eip.nat_gateway[0]'` to avoid replacement on next apply.