### PR TITLE
fix: BYOVPC-mode bugs in subnets, routing, S3 endpoint, mgmt bucket

### DIFF
--- a/nat.tf
+++ b/nat.tf
@@ -38,7 +38,7 @@ resource "aws_route" "nat" {
 
 resource "aws_route" "public" {
   count                  = local.create_vpc || var.create_internet_gateway ? 1 : 0
-  route_table_id         = aws_route_table.main.id
+  route_table_id         = aws_route_table.main[0].id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.redpanda[0].id
 }

--- a/network.tf
+++ b/network.tf
@@ -49,7 +49,7 @@ resource "aws_subnet" "public" {
   vpc_id                  = data.aws_vpc.redpanda.id
   availability_zone_id    = element(local.zones, count.index)
   cidr_block              = var.public_subnet_cidrs[count.index]
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = var.public_subnet_map_public_ip_on_launch
 
   tags = merge(
     var.default_tags,
@@ -100,11 +100,20 @@ data "aws_vpc_endpoint_service" "s3" {
 
 # Creates a private gateway vpc endpoint for S3 traffic. So traffic to S3
 # doesn't go through the NAT gateway, which is more expensive.
+# Set var.create_s3_gateway_endpoint = false when an S3 gateway endpoint
+# already exists in the BYOVPC and is attached to the relevant route tables
+# (managed by the customer's networking IaC).
 resource "aws_vpc_endpoint" "s3" {
+  count             = var.create_s3_gateway_endpoint ? 1 : 0
   vpc_id            = data.aws_vpc.redpanda.id
   service_name      = data.aws_vpc_endpoint_service.s3.service_name
   vpc_endpoint_type = data.aws_vpc_endpoint_service.s3.service_type
   tags              = var.default_tags
+}
+
+moved {
+  from = aws_vpc_endpoint.s3
+  to   = aws_vpc_endpoint.s3[0]
 }
 
 # This block has 2 purposes:

--- a/outputs.tf
+++ b/outputs.tf
@@ -97,10 +97,8 @@ output "permissions_boundary_policy_arn" {
 }
 
 output "private_subnet_arns" {
-  description = "List of private subnet ARNs"
-  value       = [
-    for subnet in aws_subnet.private : subnet.arn
-  ]
+  description = "List of private subnet ARNs (works for both BYOVPC and module-created subnets)"
+  value       = [for s in data.aws_subnet.private : s.arn]
   precondition {
     condition     = length(data.aws_subnet.private) > 0
     error_message = "Either the variable private_subnet_cidrs or private_subnet_ids is required."

--- a/routing.tf
+++ b/routing.tf
@@ -1,6 +1,12 @@
 resource "aws_route_table" "main" {
+  count  = local.create_vpc ? 1 : 0
   vpc_id = data.aws_vpc.redpanda.id
   tags   = var.default_tags
+}
+
+moved {
+  from = aws_route_table.main
+  to   = aws_route_table.main[0]
 }
 
 resource "aws_route_table" "private" {
@@ -16,14 +22,20 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_main_route_table_association" "vpc-main-route-table" {
+  count          = local.create_vpc ? 1 : 0
   vpc_id         = data.aws_vpc.redpanda.id
-  route_table_id = aws_route_table.main.id
+  route_table_id = aws_route_table.main[0].id
+}
+
+moved {
+  from = aws_main_route_table_association.vpc-main-route-table
+  to   = aws_main_route_table_association.vpc-main-route-table[0]
 }
 
 resource "aws_route_table_association" "public" {
   count          = length(var.public_subnet_cidrs)
   subnet_id      = aws_subnet.public[count.index].id
-  route_table_id = aws_route_table.main.id
+  route_table_id = aws_route_table.main[0].id
 }
 
 resource "aws_route_table_association" "private" {
@@ -34,12 +46,13 @@ resource "aws_route_table_association" "private" {
 
 # Routes S3 traffic to the local gateway endpoint
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  count           = local.create_private_subnets ? length(var.private_subnet_cidrs) : 0
-  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+  count           = local.create_private_subnets && var.create_s3_gateway_endpoint ? length(var.private_subnet_cidrs) : 0
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
   route_table_id  = aws_route_table.private[count.index].id
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {
-  vpc_endpoint_id = aws_vpc_endpoint.s3.id
-  route_table_id  = aws_route_table.main.id
+  count           = local.create_vpc && length(var.public_subnet_cidrs) > 0 && var.create_s3_gateway_endpoint ? 1 : 0
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  route_table_id  = aws_route_table.main[0].id
 }

--- a/storage.tf
+++ b/storage.tf
@@ -33,7 +33,7 @@ resource "aws_s3_bucket_ownership_controls" "redpanda_cloud_storage" {
 # S3 bucket used for terraform state and other data plane configuration
 resource "aws_s3_bucket" "management" {
   bucket_prefix = "rp-${local.aws_account_id}-${var.region}-mgmt-"
-  force_destroy = true
+  force_destroy = var.force_destroy_management_bucket
   tags          = var.default_tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -149,6 +149,36 @@ variable "force_destroy_cloud_storage" {
   HELP
 }
 
+variable "force_destroy_management_bucket" {
+  type        = bool
+  default     = true
+  description = <<-HELP
+  When true the management bucket will be destroyed when running terraform destroy, even if it contains
+  versioned Terraform state objects. Defaults to true to preserve existing module behavior. Set to false in
+  production deployments where the operator wants terraform destroy to fail rather than silently delete state.
+  HELP
+}
+
+variable "create_s3_gateway_endpoint" {
+  type        = bool
+  default     = true
+  description = <<-HELP
+  When true the module creates an S3 gateway VPC endpoint inside the VPC. Set to false when the BYOVPC already
+  has an S3 gateway endpoint attached to its private route tables (managed by the customer's networking IaC) to
+  avoid duplicating the endpoint.
+  HELP
+}
+
+variable "public_subnet_map_public_ip_on_launch" {
+  type        = bool
+  default     = true
+  description = <<-HELP
+  Controls map_public_ip_on_launch on subnets created from var.public_subnet_cidrs. Defaults to true to preserve
+  existing module behavior. Set to false in environments where SCPs deny ec2:ModifySubnetAttribute or where the
+  operator does not want auto-assigned public IPs.
+  HELP
+}
+
 variable "source_cluster_bucket_names" {
   type        = set(string)
   default     = []


### PR DESCRIPTION
Addresses several BYOVPC-mode issues described in #46. Each change is independently useful; happy to split into smaller PRs if reviewers prefer.

## Summary

| Letter (#46) | Severity | What this PR does |
|---|---|---|
| A | High | Fix `private_subnet_arns` output — was empty in BYOVPC mode |
| B | High | Stop replacing the customer's main route table when they bring their own VPC |
| C | High | Make `map_public_ip_on_launch` on public subnets configurable (default unchanged) |
| D | Medium | Make S3 gateway endpoint creation opt-out via `create_s3_gateway_endpoint` |
| F | Medium | Add count guards on the S3 endpoint route-table associations |
| G | Medium | Make management bucket `force_destroy` configurable (default unchanged) |

Bugs E, H, I from #46 are not addressed here — they need design discussion.

## Behavior

- **Default behavior is preserved.** Every new variable defaults to the current hardcoded value, so existing deployments see no change in plan output beyond the `moved` blocks below.
- BYOVPC deployments (where `vpc_id` is set) no longer create the module-owned main RT, no longer take it over via `aws_main_route_table_association`, and no longer create a duplicate S3 gateway endpoint when `create_s3_gateway_endpoint = false`.

## State migrations

Three `moved` blocks are added so existing state migrates without resource recreation:

```hcl
moved {
  from = aws_route_table.main
  to   = aws_route_table.main[0]
}

moved {
  from = aws_main_route_table_association.vpc-main-route-table
  to   = aws_main_route_table_association.vpc-main-route-table[0]
}

moved {
  from = aws_vpc_endpoint.s3
  to   = aws_vpc_endpoint.s3[0]
}
```

For BYOVPC users who want to detach the module's main RT from their VPC, after this change the module-created `aws_route_table.main` is destroyed and the original main RT regains its association.

## New variables

| Variable | Default | Purpose |
|---|---|---|
| `public_subnet_map_public_ip_on_launch` | `true` | Lets operators disable auto-assigned public IPs on module-created public subnets (e.g. when `ec2:ModifySubnetAttribute` is restricted) |
| `create_s3_gateway_endpoint` | `true` | Skip the module-owned S3 gateway endpoint when one already exists in the BYOVPC |
| `force_destroy_management_bucket` | `true` | Mirrors `force_destroy_cloud_storage`. Production deployments can override to `false` |

## Validation

`terraform validate` passes against `main` after the changes for all combinations of the new variables. No external dependencies changed.

## Repro for the BYOVPC bugs

```hcl
module \"redpanda\" {
  source              = \"redpanda-data/redpanda-byovpc/aws\"
  region              = \"ap-south-1\"
  vpc_id              = \"vpc-xxxx\"
  vpc_cidr_block      = \"10.198.0.0/16\"
  private_subnet_ids  = [\"subnet-aaa\", \"subnet-bbb\"]
  public_subnet_cidrs = []

  create_internet_gateway = false
  create_private_s3_route = false
}
```

Without this PR:
- `module.redpanda.private_subnet_arns` is empty (Bug A).
- The customer's pre-existing main route table on `vpc-xxxx` is replaced by a module-managed one (Bug B).
- A duplicate S3 gateway endpoint is created if the customer already has one (Bug D).

After this PR (with `create_s3_gateway_endpoint = false` if appropriate):
- `private_subnet_arns` returns the actual ARNs.
- The customer's main RT is left alone.
- No duplicate S3 endpoint.

## Test plan

- [ ] BYOVPC deployment with `private_subnet_ids` populated — confirm `private_subnet_arns` returns the customer's subnet ARNs.
- [ ] BYOVPC deployment — confirm the customer's existing main RT is unchanged after apply.
- [ ] BYOVPC deployment with `create_s3_gateway_endpoint = false` — confirm the module does not create an S3 endpoint and does not attempt the route-table associations.
- [ ] Module-created VPC path (existing default behavior) — confirm plan is unchanged aside from the `moved` blocks.
- [ ] `force_destroy_management_bucket = false` — confirm `terraform destroy` errors out cleanly when the bucket has objects, instead of silently deleting them.

Fixes #46 (partial — items A, B, C, D, F, G).