### PR TITLE
fix: deprecate misnamed private_subnet_ids output, add private_subnet_id_list

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -44,7 +44,21 @@ output "vpc_arn" {
 
 output "private_subnet_ids" {
   value       = jsonencode([for o in data.aws_subnet.private : o["arn"]])
-  description = "Private subnet IDs created"
+  description = <<-DESC
+  DEPRECATED. Despite the name, this output returns the private subnet ARNs
+  encoded as a JSON string (legacy behavior). Use `private_subnet_arns`
+  for a list of ARNs and `private_subnet_id_list` for a list of subnet IDs.
+  This output will be removed in a future release.
+  DESC
+  precondition {
+    condition     = length(data.aws_subnet.private) > 0
+    error_message = "Either the variable private_subnet_cidrs or private_subnet_ids is required."
+  }
+}
+
+output "private_subnet_id_list" {
+  description = "List of private subnet IDs (works for both BYOVPC and module-created subnets)"
+  value       = [for s in data.aws_subnet.private : s.id]
   precondition {
     condition     = length(data.aws_subnet.private) > 0
     error_message = "Either the variable private_subnet_cidrs or private_subnet_ids is required."
@@ -98,7 +112,7 @@ output "permissions_boundary_policy_arn" {
 
 output "private_subnet_arns" {
   description = "List of private subnet ARNs"
-  value       = [
+  value = [
     for subnet in aws_subnet.private : subnet.arn
   ]
   precondition {


### PR DESCRIPTION
Addresses item **I** in #46.

## Summary

The existing `private_subnet_ids` output returns subnet **ARNs** encoded as a JSON string, despite its name suggesting it returns subnet IDs. Renaming or changing its return type would break every existing caller, so this PR takes the conservative path:

1. Document the legacy behavior in the output description and mark it deprecated.
2. Add a new `private_subnet_id_list` output that returns the actual list of subnet IDs (`list[string]`) and works for both BYOVPC and module-created paths.

After this PR (and once #47 — addressing item A — also lands), the canonical outputs are:

| Output | Type | Purpose |
|---|---|---|
| `private_subnet_arns` | `list(string)` | List of subnet ARNs (fixed in #47) |
| `private_subnet_id_list` | `list(string)` | List of subnet IDs (new in this PR) |
| `private_subnet_ids` | `string` | JSON-encoded ARN list (legacy, deprecated) |

## Behavior

- **Existing callers unaffected.** `private_subnet_ids` continues to return the same JSON-encoded string of ARNs.
- New consumers should use `private_subnet_id_list` when they need IDs and `private_subnet_arns` when they need ARNs.
- The deprecation note in the description is the only signal to begin migrating away.

## Diff

```diff
 output "private_subnet_ids" {
   value       = jsonencode([for o in data.aws_subnet.private : o["arn"]])
-  description = "Private subnet IDs created"
+  description = <<-DESC
+  DEPRECATED. Despite the name, this output returns the private subnet ARNs
+  encoded as a JSON string (legacy behavior). Use `private_subnet_arns`
+  for a list of ARNs and `private_subnet_id_list` for a list of subnet IDs.
+  This output will be removed in a future release.
+  DESC
   ...
 }

+output "private_subnet_id_list" {
+  description = "List of private subnet IDs (works for both BYOVPC and module-created subnets)"
+  value       = [for s in data.aws_subnet.private : s.id]
+  ...
+}
```

## Test plan

- [ ] BYOVPC deployment with `private_subnet_ids` populated — confirm `private_subnet_id_list` returns the customer's subnet IDs.
- [ ] Module-created VPC path — confirm `private_subnet_id_list` returns the IDs of the newly-created subnets.
- [ ] `private_subnet_ids` still returns the JSON-encoded ARN list (unchanged).
- [ ] `terraform validate` passes (verified locally).

Refs #46 (item I).