### PR TITLE
feat(rpsql): BYOVPC infrastructure for Redpanda SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This module deploys several core components:
 4. The module includes proper tag handling for all resources using `default_tags`.
 5. For read replica clusters, configure `source_cluster_bucket_names` and `reader_cluster_id`.
 6. It can be useful to add ignore_tags to your workspace AWS provider declaration to avoid Terraform attempting to remove tags applied by external automation. More information is available here: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging#ignoring-changes-in-all-resources
+7. To enable Redpanda SQL, set `enable_redpanda_sql = true`. The module creates the cloud-storage S3 bucket (server-side encryption AES256, versioning Disabled, public access blocked) along with a dedicated node-group IAM instance profile and security group. Wire the module outputs `rpsql_node_group_instance_profile_arn`, `rpsql_security_group_arn`, and `rpsql_cloud_storage_bucket_arn` into the Redpanda cluster's customer-managed resources (`rpsql_node_group_instance_profile`, `rpsql_security_group`, and `rpsql_cloud_storage_bucket`).
 
 ## Examples
 

--- a/iam_redpanda_agent.tf
+++ b/iam_redpanda_agent.tf
@@ -337,7 +337,8 @@ data "aws_iam_policy_document" "redpanda_agent1" {
       aws_iam_instance_profile.redpanda_node_group.arn,
       aws_iam_instance_profile.utility.arn,
       aws_iam_instance_profile.connectors_node_group.arn
-    ], var.enable_redpanda_connect ? [aws_iam_instance_profile.redpanda_connect_node_group[0].arn] : [])
+      ], var.enable_redpanda_connect ? [aws_iam_instance_profile.redpanda_connect_node_group[0].arn] : [],
+    var.enable_redpanda_sql ? [aws_iam_instance_profile.rpsql_node_group[0].arn] : [])
   }
 }
 
@@ -377,7 +378,7 @@ data "aws_iam_policy_document" "redpanda_agent2" {
       "iam:ListPolicyVersions",
       "iam:ListPolicyTags",
     ]
-    resources = [
+    resources = concat([
       aws_iam_policy.aws_ebs_csi_driver_policy.arn,
       aws_iam_policy.cert_manager.arn,
       aws_iam_policy.external_dns_policy.arn,
@@ -393,8 +394,12 @@ data "aws_iam_policy_document" "redpanda_agent2" {
       "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-cluster-secrets-reader",
       "arn:aws:iam::${local.aws_account_id}:policy/redpanda-console-secrets-manager-*",
       "arn:aws:iam::${local.aws_account_id}:policy/redpanda-cloud-storage-manager-*",
-      "arn:aws:iam::aws:policy/Amazon*"
-    ]
+      "arn:aws:iam::aws:policy/Amazon*",
+      ], var.enable_redpanda_sql ? [
+      "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-redpanda-oxla-api",
+      "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-redpanda-oxla-cluster",
+      "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-redpanda-oxla-cluster-iceberg",
+    ] : [])
   }
 
   statement {
@@ -420,7 +425,12 @@ data "aws_iam_policy_document" "redpanda_agent2" {
       aws_iam_role.redpanda_utility_node_group.arn,
       aws_iam_role.connectors_node_group.arn,
       aws_iam_role.k8s_cluster.arn,
-    ], var.enable_redpanda_connect ? [aws_iam_role.redpanda_connect_node_group[0].arn] : [])
+      ], var.enable_redpanda_connect ? [aws_iam_role.redpanda_connect_node_group[0].arn] : [],
+      var.enable_redpanda_sql ? [
+        aws_iam_role.rpsql_node_group[0].arn,
+        "arn:aws:iam::${local.aws_account_id}:role/redpanda-*-redpanda-oxla-api",
+        "arn:aws:iam::${local.aws_account_id}:role/redpanda-*-redpanda-oxla-cluster",
+    ] : [])
   }
 
   statement {
@@ -444,6 +454,21 @@ data "aws_iam_policy_document" "redpanda_agent2" {
       aws_s3_bucket.redpanda_cloud_storage.arn,
       "${aws_s3_bucket.redpanda_cloud_storage.arn}/*",
     ]
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_redpanda_sql ? [aws_s3_bucket.rpsql[0].arn] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "s3:List*",
+        "s3:Get*",
+      ]
+      resources = [
+        statement.value,
+        "${statement.value}/*",
+      ]
+    }
   }
 
   statement {
@@ -575,6 +600,20 @@ data "aws_iam_policy_document" "agent_permission_boundary" {
       aws_s3_bucket.redpanda_cloud_storage.arn,
       "${aws_s3_bucket.redpanda_cloud_storage.arn}/*",
     ]
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_redpanda_sql ? [aws_s3_bucket.rpsql[0].arn] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "s3:*",
+      ]
+      resources = [
+        statement.value,
+        "${statement.value}/*",
+      ]
+    }
   }
 
   statement {
@@ -804,7 +843,7 @@ data "aws_iam_policy_document" "redpanda_agent_private_link" {
     actions = [
       "elasticloadbalancing:AddTags",
     ]
-    resources = [
+    resources = concat([
       # the ID of the load balancer is not known until after the cluster has been created
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:loadbalancer/net/*",
 
@@ -814,8 +853,10 @@ data "aws_iam_policy_document" "redpanda_agent_private_link" {
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-rp-*",
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-kf-*/*",
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-seed/*",
-      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-console/*"
-    ]
+      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-console/*",
+      ], var.enable_redpanda_sql ? [
+      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-oxla*",
+    ] : [])
     # Limit this statement to create operations only
     condition {
       test     = "StringEquals"
@@ -848,7 +889,7 @@ data "aws_iam_policy_document" "redpanda_agent_private_link" {
       "elasticloadbalancing:AddTags",
       "elasticloadbalancing:RemoveTags",
     ]
-    resources = [
+    resources = concat([
       # the ID of the load balancer is not known until after the cluster has been created
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:loadbalancer/net/*",
 
@@ -858,8 +899,10 @@ data "aws_iam_policy_document" "redpanda_agent_private_link" {
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-rp-*",
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-kf-*/*",
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-seed/*",
-      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-console/*"
-    ]
+      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-console/*",
+      ], var.enable_redpanda_sql ? [
+      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-oxla*",
+    ] : [])
     # Validate that the existing resource already has the required condition_tags
     # This allows tagging operations on resources that were previously created with the correct tags
     dynamic "condition" {
@@ -879,12 +922,14 @@ data "aws_iam_policy_document" "redpanda_agent_private_link" {
     actions = [
       "elasticloadbalancing:CreateTargetGroup",
     ]
-    resources = [
+    resources = concat([
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-rp-*",
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-kf-*/*",
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-seed/*",
-      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-console/*"
-    ]
+      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-console/*",
+      ], var.enable_redpanda_sql ? [
+      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-oxla*",
+    ] : [])
     dynamic "condition" {
       for_each = var.condition_tags
       content {
@@ -925,12 +970,14 @@ data "aws_iam_policy_document" "redpanda_agent_private_link" {
       "elasticloadbalancing:ModifyTargetGroupAttributes",
       "elasticloadbalancing:RegisterTargets",
     ]
-    resources = [
+    resources = concat([
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-rp-*",
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-kf-*/*",
       "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-seed/*",
-      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-console/*"
-    ]
+      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-console/*",
+      ], var.enable_redpanda_sql ? [
+      "arn:aws:elasticloadbalancing:${var.region}:${local.aws_account_id}:targetgroup/*-oxla*",
+    ] : [])
     dynamic "condition" {
       for_each = var.condition_tags
       content {

--- a/iam_rpk_user.tf
+++ b/iam_rpk_user.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "byovpc_rpk_user_1" {
       "iam:GetPolicyVersion",
       "iam:ListPolicyVersions",
     ]
-    resources = [
+    resources = concat([
       "arn:aws:iam::${local.aws_account_id}:policy/redpanda-connectors-secrets-manager-*",
       "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-redpanda-connect-secrets-manager",
       "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-redpanda-connect-pipeline-secrets-manager",
@@ -78,7 +78,10 @@ data "aws_iam_policy_document" "byovpc_rpk_user_1" {
       aws_iam_policy.load_balancer_controller_policy["2"].arn,
       aws_iam_policy.external_dns_policy.arn,
       aws_iam_policy.cert_manager.arn,
-    ]
+      ], var.enable_redpanda_sql ? [
+      "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-redpanda-oxla-api",
+      "arn:aws:iam::${local.aws_account_id}:policy/redpanda-*-redpanda-oxla-cluster",
+    ] : [])
   }
 
   statement {
@@ -101,7 +104,8 @@ data "aws_iam_policy_document" "byovpc_rpk_user_1" {
       aws_iam_instance_profile.redpanda_node_group.arn,
       aws_iam_instance_profile.utility.arn,
       aws_iam_instance_profile.connectors_node_group.arn,
-    ], var.enable_redpanda_connect ? [aws_iam_instance_profile.redpanda_connect_node_group[0].arn] : [])
+      ], var.enable_redpanda_connect ? [aws_iam_instance_profile.redpanda_connect_node_group[0].arn] : [],
+    var.enable_redpanda_sql ? [aws_iam_instance_profile.rpsql_node_group[0].arn] : [])
   }
 
   statement {
@@ -125,7 +129,12 @@ data "aws_iam_policy_document" "byovpc_rpk_user_1" {
       aws_iam_role.redpanda_utility_node_group.arn,
       aws_iam_role.connectors_node_group.arn,
       "arn:aws:iam::${local.aws_account_id}:role/${var.common_prefix}-rpk-user-role-*",
-    ], var.enable_redpanda_connect ? [aws_iam_role.redpanda_connect_node_group[0].arn] : [])
+      ], var.enable_redpanda_connect ? [aws_iam_role.redpanda_connect_node_group[0].arn] : [],
+      var.enable_redpanda_sql ? [
+        aws_iam_role.rpsql_node_group[0].arn,
+        "arn:aws:iam::${local.aws_account_id}:role/redpanda-*-redpanda-oxla-api",
+        "arn:aws:iam::${local.aws_account_id}:role/redpanda-*-redpanda-oxla-cluster",
+    ] : [])
   }
 
   statement {
@@ -291,6 +300,23 @@ data "aws_iam_policy_document" "byovpc_rpk_user_2" {
       aws_s3_bucket.redpanda_cloud_storage.arn,
       "${aws_s3_bucket.redpanda_cloud_storage.arn}/*",
     ]
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_redpanda_sql ? [aws_s3_bucket.rpsql[0].arn] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "s3:ListBucket",
+        "s3:GetBucketVersioning",
+        "s3:GetEncryptionConfiguration",
+        "s3:GetBucketPublicAccessBlock",
+      ]
+      resources = [
+        statement.value,
+        "${statement.value}/*",
+      ]
+    }
   }
 
   statement {

--- a/iam_rpsql_node_group.tf
+++ b/iam_rpsql_node_group.tf
@@ -1,0 +1,47 @@
+data "aws_iam_policy_document" "rpsql_node_group_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "rpsql_node_group" {
+  count                 = var.enable_redpanda_sql ? 1 : 0
+  name_prefix           = "${var.common_prefix}-rpsql-"
+  path                  = "/"
+  force_detach_policies = true
+  tags = merge(
+    var.default_tags,
+    {
+      "redpanda-client" = "rp-sql"
+    }
+  )
+  assume_role_policy = data.aws_iam_policy_document.rpsql_node_group_trust.json
+}
+
+resource "aws_iam_instance_profile" "rpsql_node_group" {
+  count       = var.enable_redpanda_sql ? 1 : 0
+  name_prefix = "${var.common_prefix}-rpsql-"
+  path        = "/"
+  role        = aws_iam_role.rpsql_node_group[0].name
+  tags = merge(
+    var.default_tags,
+    {
+      "redpanda-client" = "rp-sql"
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "rpsql_node_group" {
+  for_each = var.enable_redpanda_sql ? {
+    "1" = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+    "2" = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+    "3" = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  } : {}
+  policy_arn = each.value
+  role       = aws_iam_role.rpsql_node_group[0].name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,10 @@ output "redpanda_connect_node_group_instance_profile_arn" {
   value = var.enable_redpanda_connect ? aws_iam_instance_profile.redpanda_connect_node_group[0].arn : null
 }
 
+output "rpsql_node_group_instance_profile_arn" {
+  value = var.enable_redpanda_sql ? aws_iam_instance_profile.rpsql_node_group[0].arn : null
+}
+
 output "utility_node_group_instance_profile_arn" {
   value = aws_iam_instance_profile.utility.arn
 }
@@ -28,6 +32,11 @@ output "agent_instance_profile_arn" {
 
 output "cloud_storage_bucket_arn" {
   value = aws_s3_bucket.redpanda_cloud_storage.arn
+}
+
+output "rpsql_cloud_storage_bucket_arn" {
+  value       = var.enable_redpanda_sql ? aws_s3_bucket.rpsql[0].arn : null
+  description = "ARN of the module-managed S3 bucket used for Redpanda SQL cloud storage"
 }
 
 output "management_bucket_arn" {
@@ -78,6 +87,11 @@ output "connectors_security_group_arn" {
 output "redpanda_connect_security_group_arn" {
   value       = var.enable_redpanda_connect ? aws_security_group.redpanda_connect[0].arn : null
   description = "Redpanda Connect security group ARN"
+}
+
+output "rpsql_security_group_arn" {
+  value       = var.enable_redpanda_sql ? aws_security_group.rpsql[0].arn : null
+  description = "Redpanda SQL security group ARN"
 }
 
 output "redpanda_node_group_security_group_arn" {

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -67,6 +67,53 @@ resource "aws_security_group_rule" "redpanda_connect" {
 }
 
 // -----------------------------
+// Redpanda SQL security group
+// -----------------------------
+resource "aws_security_group" "rpsql" {
+  count       = var.enable_redpanda_sql ? 1 : 0
+  name_prefix = "${var.common_prefix}-rpsql-"
+  description = "Redpanda SQL nodes"
+  vpc_id      = data.aws_vpc.redpanda.id
+  lifecycle {
+    create_before_destroy = true
+  }
+  tags = var.default_tags
+}
+
+resource "aws_security_group_rule" "rpsql" {
+  count             = var.enable_redpanda_sql ? 1 : 0
+  security_group_id = aws_security_group.rpsql[0].id
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  type              = "egress"
+  description       = "Allow all egress traffic"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "rpsql_ingress_healthcheck" {
+  count             = var.enable_redpanda_sql ? 1 : 0
+  security_group_id = aws_security_group.rpsql[0].id
+  protocol          = "tcp"
+  from_port         = 30431
+  to_port           = 30431
+  type              = "ingress"
+  description       = "Allow NLB health check traffic to Redpanda SQL nodes"
+  cidr_blocks       = local.rp_node_group_cidr_blocks
+}
+
+resource "aws_security_group_rule" "rpsql_ingress_data" {
+  count             = var.enable_redpanda_sql ? 1 : 0
+  security_group_id = aws_security_group.rpsql[0].id
+  protocol          = "tcp"
+  from_port         = 30432
+  to_port           = 30432
+  type              = "ingress"
+  description       = "Allow NLB data traffic to Redpanda SQL nodes"
+  cidr_blocks       = local.rp_node_group_cidr_blocks
+}
+
+// -----------------------------
 // Utility security group
 // -----------------------------
 resource "aws_security_group" "utility" {

--- a/storage_rpsql.tf
+++ b/storage_rpsql.tf
@@ -1,0 +1,46 @@
+# S3 bucket used for Redpanda SQL cloud storage (module-managed in BYOVPC mode).
+# The ARN is exposed via the rpsql_cloud_storage_bucket_arn output so it can be
+# wired into the cluster's rpsql_cloud_storage_bucket customer-managed resource.
+resource "aws_s3_bucket" "rpsql" {
+  count         = var.enable_redpanda_sql ? 1 : 0
+  bucket_prefix = "redpanda-rpsql-cloud-storage-"
+  force_destroy = var.force_destroy_cloud_storage
+  tags          = var.default_tags
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "rpsql" {
+  count  = var.enable_redpanda_sql ? 1 : 0
+  bucket = aws_s3_bucket.rpsql[0].bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "rpsql" {
+  count  = var.enable_redpanda_sql ? 1 : 0
+  bucket = aws_s3_bucket.rpsql[0].id
+  versioning_configuration {
+    # versioning on the cloud storage bucket is not recommended
+    status = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "rpsql" {
+  count                   = var.enable_redpanda_sql ? 1 : 0
+  bucket                  = aws_s3_bucket.rpsql[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "rpsql" {
+  count  = var.enable_redpanda_sql ? 1 : 0
+  bucket = aws_s3_bucket.rpsql[0].id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -214,6 +214,14 @@ variable "enable_redpanda_connect" {
   HELP
 }
 
+variable "enable_redpanda_sql" {
+  type        = bool
+  default     = false
+  description = <<-HELP
+  When true grants additional permissions and resources required by Redpanda SQL.
+  HELP
+}
+
 variable "create_private_s3_route" {
   type        = bool
   default     = false


### PR DESCRIPTION
Add the AWS infrastructure the BYOVPC Terraform module needs to run Redpanda SQL (rpsql), all gated behind enable_redpanda_sql:

- rpsql node group IAM role, instance profile, and policy attachments (iam_rpsql_node_group.tf)
- agent IAM: create/manage/read the rpsql cluster and API policies and roles, including read on the rpsql cluster Iceberg S3 policy (iam_redpanda_agent.tf)
- rpk-user IAM: read access to rpsql resources for apply-time validation (iam_rpk_user.tf)
- rpsql security group + Redpanda SQL NodePort ingress rules (security_groups.tf)
- module-managed, customer-supplied SQL cloud-storage S3 bucket (storage_rpsql.tf)
- adopt the rpsql name for public-facing SQL resources and gate all rpsql IAM ARN patterns behind enable_redpanda_sql (variables.tf, outputs.tf)
- network/nat/routing/outputs cleanup